### PR TITLE
Add CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout
+      - run:
+          name: Run tests
+          command: |
+            go get gotest.tools/gotestsum@v0.4.0
+            mkdir -p test-results/gotestsum
+            gotestsum --junitfile test-results/gotestsum/results.xml -f short-verbose -- ./...
+      - run: 
+          name: Run benchmarks
+          command: go test -bench .
+      - store_test_results:
+          path: test-results

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # quantiles - Optimal Quantile Approximation in Streams
-[![GoDoc](https://godoc.org/github.com/axiomhq/quantiles?status.svg)](https://godoc.org/github.com/axiomhq/quantiles)
+[![GoDoc](https://godoc.org/github.com/axiomhq/quantiles?status.svg)](https://godoc.org/github.com/axiomhq/quantiles) [![CircleCI](https://circleci.com/gh/axiomhq/quantiles/tree/master.svg?style=svg)](https://circleci.com/gh/axiomhq/quantiles/tree/master)
 
 This is a translation of [TensorFlow's quantile helper class](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/contrib/boosted_trees/lib/quantiles), it aims to compute approximate quantiles with error bound guarantees for weighted data sets.
 This implementation is an adaptation of techniques from the following papers:


### PR DESCRIPTION
This configure CircleCI and runs tests and benchmarks on every push. It collects test-results with `gotestsum` to show a summary.

It also adds a badge showing the build status of `master`.

[![Screenshot 2019-11-12 at 14 19 20](https://user-images.githubusercontent.com/1725839/68675152-977bfb80-0557-11ea-9fbc-b6e64b0ef20f.png)](https://circleci.com/gh/bahlo/quantiles/2)

Before merging this, please go to [Add Projects](https://circleci.com/add-projects/gh/axiomhq) on CircleCI and click `Set Up Project` next to this project, then `Start Building`.